### PR TITLE
Bump Canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "canvas": "~1.0.1"
+    "canvas": "~1.1.1"
   },
   "devDependencies": {
     "uglify-js": "~1.3.2",


### PR DESCRIPTION
Canvas version 1.1.1 adds support for Giflib 5 ([relevant commit](https://github.com/LearnBoost/node-canvas/commit/a0632275c53d0ed4811a96fb7bf12ebd5668f289)) which is the version available on some platforms, such as Arch Linux for instance.
Bumping the version of Canvas will make it possible to use histogram on those platforms without going through the trouble of installing an old version of the library.
