### PR TITLE
Upgrade node-canvas to v1.3.10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "canvas": "1.2.10"
+    "canvas": "1.3.10"
   },
   "devDependencies": {
     "coveralls": "2.11.4",


### PR DESCRIPTION
The node-canvas v1.2.10 version fails to compile on my machine. This has apparently been fixed in more recent versions. All the tests run successfully, so it should be fairly safe to upgrade. I'll buy you a beer if you merge this in :smile: 