### PR TITLE
Update canvas to 1.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "canvas": "1.6.2"
+    "canvas": "^1.6.7"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.2.0",
     "mocha-phantomjs-core": "^2.0.1",
-    "phantomjs-prebuilt": "^2.1.7",
+    "phantomjs-prebuilt": "^2.1.15",
     "uglify-js": "^2.6.2",
     "unexpected": "^10.13.3"
   },


### PR DESCRIPTION
The old version of canvas was not compatible with latest stable node version.

Had to upgrade phantomjs to get the tests running - I'm not sure why - I had a clean fork and checkout of this module.