### PR TITLE
Canvas prebuilt

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -64,7 +64,7 @@
     "couch"         : false,    // CouchDB
     "devel"         : true,     // Development/debugging (alert, confirm, etc)
     "dojo"          : false,    // Dojo Toolkit
-    "jquery"        : true,     // jQuery
+    "jquery"        : false,     // jQuery
     "mootools"      : false,    // MooTools
     "node"          : false,    // Node.js
     "nonstandard"   : true,     // Widely adopted globals (escape, unescape, etc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "6"
   - "8"
   - "10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 services:
   - docker
 language: node_js
@@ -6,17 +5,9 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "4"
   - "6"
   - "8"
-addons:
-  apt:
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - libpango1.0-dev
-      - libgif-dev
-env: CXX="g++-4.8" CC="gcc-4.8"
+  - "10"
 
 script: "npm run-script travis"
 after_success: "<coverage/lcov.info ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,3 @@ License
 -------
 This software is licensed under the beerware license. Do whatever you want with it.
 If we meet some day, and you think this stuff is worth it, you can buy me a beer in return.
-
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/Munter/node-histogram/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 (function () {
     var Canvas,
+        Image,
         getCanvasImageData = function (imageBuffer, callback) {
-            var canvasImage = new Canvas.Image();
+            var canvasImage = new Image();
 
             canvasImage.onerror = function () {
                 callback(new Error('error while reading from input stream'));
@@ -108,7 +109,9 @@
 
     if (typeof exports === 'object') {
         // Assume nodejs
-        Canvas = require('canvas');
+        var canvasPrebuilt = require('canvas-prebuilt');
+        Canvas = canvasPrebuilt.Canvas;
+        Image = canvasPrebuilt.Image;
         module.exports = histogram;
     } else {
         // Polyfill canvas constructor
@@ -119,7 +122,7 @@
 
             return canvas;
         };
-        Canvas.Image = Image;
+        Image = window.Image;
 
         if (typeof define === 'function') {
             // AMD module

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
         Image,
         getCanvasImageData = function (imageBuffer, callback) {
             var canvasImage = new Image();
+            canvasImage.crossOrigin = 'Anonymous';
 
             canvasImage.onerror = function () {
                 callback(new Error('error while reading from input stream'));

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "canvas-prebuilt": "2.0.0-alpha.14"
   },
   "devDependencies": {
-    "coveralls": "^2.11.9",
+    "coveralls": "3.0.2",
     "jshint": "2.9.6",
-    "mocha": "^3.0.2",
-    "mocha-lcov-reporter": "1.3.0",
-    "mocha-phantomjs": "4.1.0",
-    "uglify-js": "^2.6.2",
+    "mocha": "5.2.0",
+    "mocha-chrome": "1.1.0",
+    "nyc": "13.1.0",
+    "uglify-js": "3.4.9",
     "unexpected": "10.39.1"
   },
   "optionalDependencies": {},
@@ -51,9 +51,9 @@
   },
   "scripts": {
     "lint": "jshint .",
-    "test": "npm run lint && mocha && mocha-phantomjs test/global.html",
+    "test": "npm run lint && mocha && mocha-chrome test/global.html --chrome-flags '[\"--allow-file-access-from-files\"]'",
     "preversion": "npm t && uglifyjs lib/index.js -m -c > histogram.min.js && git add histogram.min.js",
     "travis": "npm run lint && npm run coverage",
-    "coverage": "istanbul cover _mocha"
+    "coverage": "nyc --reporter=lcov --reporter=text mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "lib/index.js",
   "dependencies": {
-    "canvas": "^1.6.7"
+    "canvas-prebuilt": "2.0.0-alpha.14"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",
@@ -53,9 +53,8 @@
   },
   "scripts": {
     "lint": "jshint .",
-    "phantom": "phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js test/global.html spec \"`node -pe 'JSON.stringify({useColors:true,grep:process.env.grep})'`\"",
-    "test": "npm run lint && mocha && npm run phantom",
-    "preversion": "uglifyjs lib/index.js -m -c > histogram.min.js && git add histogram.min.js",
+    "test": "npm run lint && mocha && mocha-phantomjs test/global.html",
+    "preversion": "npm t && uglifyjs lib/index.js -m -c > histogram.min.js && git add histogram.min.js",
     "travis": "npm run lint && npm run coverage",
     "coverage": "istanbul cover _mocha"
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lint": "jshint .",
     "test": "npm run lint && mocha && mocha-chrome test/global.html --chrome-flags '[\"--allow-file-access-from-files\"]'",
     "preversion": "npm t && uglifyjs lib/index.js -m -c > histogram.min.js && git add histogram.min.js",
-    "travis": "npm run lint && npm run coverage",
+    "travis": "npm t && npm run coverage",
     "coverage": "nyc --reporter=lcov --reporter=text mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,17 +37,13 @@
     "canvas-prebuilt": "2.0.0-alpha.14"
   },
   "devDependencies": {
-    "coveralls": "3.0.2",
-    "jshint": "2.9.6",
-    "mocha": "5.2.0",
-    "mocha-chrome": "1.1.0",
-    "nyc": "13.1.0",
-    "uglify-js": "3.4.9",
-    "unexpected": "10.39.1"
-  },
-  "optionalDependencies": {},
-  "engines": {
-    "node": "*"
+    "coveralls": "^3.0.2",
+    "jshint": "^2.9.6",
+    "mocha": "^5.2.0",
+    "mocha-chrome": "^1.1.0",
+    "nyc": "^13.1.0",
+    "uglify-js": "^3.4.9",
+    "unexpected": "^10.39.1"
   },
   "scripts": {
     "lint": "jshint .",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,11 @@
   },
   "scripts": {
     "lint": "jshint .",
-    "test": "npm run lint && mocha && mocha-chrome test/global.html --chrome-flags '[\"--allow-file-access-from-files\"]'",
-    "preversion": "npm t && uglifyjs lib/index.js -m -c > histogram.min.js && git add histogram.min.js",
-    "travis": "npm t && npm run coverage",
-    "coverage": "nyc --reporter=lcov --reporter=text mocha"
+    "browser-test": "mocha-chrome test/global.html --chrome-flags '[\"--allow-file-access-from-files\"]'",
+    "node-test": "mocha",
+    "test": "npm run lint && npm run node-test && npm run browser-test",
+    "coverage": "nyc --reporter=lcov --reporter=text mocha",
+    "travis": "npm run lint && npm run coverage && npm run browser-test",
+    "preversion": "npm t && uglifyjs lib/index.js -m -c > histogram.min.js && git add histogram.min.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,14 +38,12 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.9",
-    "istanbul": "^0.4.3",
-    "jshint": "^2.9.2",
+    "jshint": "2.9.6",
     "mocha": "^3.0.2",
-    "mocha-lcov-reporter": "^1.2.0",
-    "mocha-phantomjs-core": "^2.0.1",
-    "phantomjs-prebuilt": "^2.1.15",
+    "mocha-lcov-reporter": "1.3.0",
+    "mocha-phantomjs": "4.1.0",
     "uglify-js": "^2.6.2",
-    "unexpected": "^10.13.3"
+    "unexpected": "10.39.1"
   },
   "optionalDependencies": {},
   "engines": {

--- a/test/global.html
+++ b/test/global.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>Mocha</title>
+    <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
   </head>
@@ -12,11 +13,7 @@
     <script src="../lib/index.js"></script>
     <script src="histogram.js"></script>
     <script>
-      if (window.mochaPhantomJS) {
-          mochaPhantomJS.run();
-      } else {
-          mocha.run();
-      }
+      mocha.run();
     </script>
   </body>
 </html>

--- a/test/histogram.js
+++ b/test/histogram.js
@@ -33,7 +33,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should be greyscale', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be', null);
+            expect(error, 'to be falsy');
             expect(result.greyscale, 'to be true');
 
             done();
@@ -42,7 +42,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should have an alpha channel', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be null');
+            expect(error, 'to be falsy');
             expect(result.alphachannel, 'to be true');
 
             done();
@@ -51,7 +51,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should have 256 alpha channel colors', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be null');
+            expect(error, 'to be falsy');
             expect(result.colors.rgba, 'to be', 256);
 
             done();
@@ -60,7 +60,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should have 1 rgba color', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be null');
+            expect(error, 'to be falsy');
             expect(result.colors.rgb, 'to be', 1);
 
             done();
@@ -73,7 +73,7 @@ describe('Histogram of gradient-red.png', function () {
 
     it('should be greyscale', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be null');
+            expect(error, 'to be falsy');
             expect(result.greyscale, 'to be false');
 
             done();
@@ -82,7 +82,7 @@ describe('Histogram of gradient-red.png', function () {
 
     it('should have an alpha channel', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be null');
+            expect(error, 'to be falsy');
             expect(result.alphachannel, 'to be true');
 
             done();
@@ -91,7 +91,7 @@ describe('Histogram of gradient-red.png', function () {
 
     it('should have 256 alpha channel colors', function (done) {
         histogram(path, function (error, result) {
-            expect(error, 'to be null');
+            expect(error, 'to be falsy');
             expect(result.colors.rgba, 'to be', 256);
 
             done();

--- a/test/histogram.js
+++ b/test/histogram.js
@@ -154,36 +154,3 @@ describe('Histogram of turtle.jpg', function () {
         });
     });
 });
-
-
-describe('Histogram of cablecar.gif', function () {
-    var path = imagePath + 'cablecar.gif';
-
-    it('should not be greyscale', function (done) {
-        histogram(path, function (error, result) {
-            expect(error, 'to be falsy');
-
-            expect(result, 'to satisfy', {
-                greyscale: false
-            });
-
-            done();
-        });
-    });
-});
-
-describe('Histogram of turtle.jpg', function () {
-    var path = imagePath + 'turtle.jpg';
-
-    it('should not be greyscale', function (done) {
-        histogram(path, function (error, result) {
-            expect(error, 'to be falsy');
-
-            expect(result, 'to satisfy', {
-                greyscale: false
-            });
-
-            done();
-        });
-    });
-});

--- a/test/histogram.js
+++ b/test/histogram.js
@@ -33,6 +33,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should be greyscale', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be', null);
             expect(result.greyscale, 'to be true');
 
             done();
@@ -41,6 +42,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should have an alpha channel', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be null');
             expect(result.alphachannel, 'to be true');
 
             done();
@@ -49,6 +51,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should have 256 alpha channel colors', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be null');
             expect(result.colors.rgba, 'to be', 256);
 
             done();
@@ -57,6 +60,7 @@ describe('Histogram of gradient.png', function () {
 
     it('should have 1 rgba color', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be null');
             expect(result.colors.rgb, 'to be', 1);
 
             done();
@@ -69,6 +73,7 @@ describe('Histogram of gradient-red.png', function () {
 
     it('should be greyscale', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be null');
             expect(result.greyscale, 'to be false');
 
             done();
@@ -77,6 +82,7 @@ describe('Histogram of gradient-red.png', function () {
 
     it('should have an alpha channel', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be null');
             expect(result.alphachannel, 'to be true');
 
             done();
@@ -85,6 +91,7 @@ describe('Histogram of gradient-red.png', function () {
 
     it('should have 256 alpha channel colors', function (done) {
         histogram(path, function (error, result) {
+            expect(error, 'to be null');
             expect(result.colors.rgba, 'to be', 256);
 
             done();

--- a/test/histogram.js
+++ b/test/histogram.js
@@ -34,7 +34,10 @@ describe('Histogram of gradient.png', function () {
     it('should be greyscale', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.greyscale, 'to be true');
+
+            expect(result, 'to satisfy', {
+                greyscale: true
+            });
 
             done();
         });
@@ -43,25 +46,35 @@ describe('Histogram of gradient.png', function () {
     it('should have an alpha channel', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.alphachannel, 'to be true');
+            expect(result, 'to satisfy', {
+                alphachannel: true
+            });
 
             done();
         });
     });
 
-    it('should have 256 alpha channel colors', function (done) {
+    it('should have 256 rgba colors', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.colors.rgba, 'to be', 256);
+            expect(result, 'to satisfy', {
+                colors: {
+                    rgba: 256
+                }
+            });
 
             done();
         });
     });
 
-    it('should have 1 rgba color', function (done) {
+    it('should have 1 rgb color', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.colors.rgb, 'to be', 1);
+            expect(result, 'to satisfy', {
+                colors: {
+                    rgb: 1
+                }
+            });
 
             done();
         });
@@ -74,7 +87,10 @@ describe('Histogram of gradient-red.png', function () {
     it('should be greyscale', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.greyscale, 'to be false');
+
+            expect(result, 'to satisfy', {
+                greyscale: false
+            });
 
             done();
         });
@@ -83,7 +99,10 @@ describe('Histogram of gradient-red.png', function () {
     it('should have an alpha channel', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.alphachannel, 'to be true');
+
+            expect(result, 'to satisfy', {
+                alphachannel: true
+            });
 
             done();
         });
@@ -92,7 +111,44 @@ describe('Histogram of gradient-red.png', function () {
     it('should have 256 alpha channel colors', function (done) {
         histogram(path, function (error, result) {
             expect(error, 'to be falsy');
-            expect(result.colors.rgba, 'to be', 256);
+
+            expect(result, 'to satisfy', {
+                colors: {
+                    rgba: 256
+                }
+            });
+
+            done();
+        });
+    });
+});
+
+describe('Histogram of cablecar.gif', function () {
+    var path = imagePath + 'cablecar.gif';
+
+    it('should not be greyscale', function (done) {
+        histogram(path, function (error, result) {
+            expect(error, 'to be falsy');
+
+            expect(result, 'to satisfy', {
+                greyscale: false
+            });
+
+            done();
+        });
+    });
+});
+
+describe('Histogram of turtle.jpg', function () {
+    var path = imagePath + 'turtle.jpg';
+
+    it('should not be greyscale', function (done) {
+        histogram(path, function (error, result) {
+            expect(error, 'to be falsy');
+
+            expect(result, 'to satisfy', {
+                greyscale: false
+            });
 
             done();
         });


### PR DESCRIPTION
Switched to canvas-prebuilt and did a lot of maintenance.

@papandreou This might be a way to remove the `cairo` dependency in assetgraph-sprite as well